### PR TITLE
Fixed three macOS bugs (save-state crash, blank Input settings, ROM double-click)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 
-on:
-  push:
-   branches:
-     - unstable
+on: push
 
 jobs:
   win64:
@@ -11,7 +8,8 @@ jobs:
     env:
       makeOptions: -j4
       makeVariables: local=false build=performance
-      nightly: bsnes-as-win64-${{github.run_number}}
+      #nightly: bsnes-as-win64-${{github.run_number}}
+      nightly: bsnes-as-win64
       buildVersion: ${{github.run_id}}
       platformOptions: platform=windows compiler="x86_64-w64-mingw32-g++-posix" windres="x86_64-w64-mingw32-windres"
 
@@ -35,18 +33,18 @@ jobs:
         shell: bash
         name: 'make bsnes'
 
-      - run: |
-          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
-        shell: bash
-        name: 'make libretro'
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
 
       - run: |
           mkdir ${{env.nightly}}
           mkdir ${{env.nightly}}/Database
           mkdir ${{env.nightly}}/Firmware
           cp -a bsnes/out/bsnes.exe ${{env.nightly}}/bsnes.exe
-          cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
+          #cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
           cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
           cp -a bsnes/Database/* ${{env.nightly}}/Database
           cp -a shaders ${{env.nightly}}/Shaders
@@ -55,10 +53,20 @@ jobs:
         shell: bash
         name: 'package'
 
+      - run: Compress-Archive -Path ${{env.nightly}}/* -Destination ${{env.nightly}}.zip
+        shell: pwsh
+        name: 'archive'
+
       - uses: actions/upload-artifact@v3
         with:
-          name: '${{env.nightly}}'
-          path: '${{env.nightly}}'
+          name: '${{env.nightly}}.zip'
+          path: '${{env.nightly}}.zip'
+
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: '${{env.nightly}}.zip'
 
 # NOTE: disabled due to compilation failures with angelscript/source/as_callfunc_x86.cpp
 #  win32:
@@ -122,7 +130,8 @@ jobs:
     env:
       makeOptions: -j4
       makeVariables: local=false build=performance
-      nightly: bsnes-as-macos-${{github.run_number}}
+      #nightly: bsnes-as-macos-${{github.run_number}}
+      nightly: bsnes-as-macos
       buildVersion: ${{github.run_id}}
       platformOptions:
 
@@ -143,25 +152,35 @@ jobs:
         shell: bash
         name: 'make bsnes'
 
-      - run: |
-          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
-        shell: bash
-        name: 'make libretro'
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
 
       - run: |
           mkdir ${{env.nightly}}
           cp -a bsnes/out/bsnes.app ${{env.nightly}}/
-          cp -a bsnes/out/bsnes_libretro.dylib ${{env.nightly}}/ || true
+          #cp -a bsnes/out/bsnes_libretro.dylib ${{env.nightly}}/ || true
           cp -a scripts ${{env.nightly}}/scripts
           cp -a GPLv3.txt ${{env.nightly}}/
         shell: bash
         name: 'package'
 
+      - run: tar cJf ${{env.nightly}}.tar.xz ${{env.nightly}}/*
+        shell: bash
+        name: 'archive'
+
       - uses: actions/upload-artifact@v3
         with:
-          name: '${{env.nightly}}'
-          path: '${{env.nightly}}'
+          name: '${{env.nightly}}.tar.xz'
+          path: '${{env.nightly}}.tar.xz'
+
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: '${{env.nightly}}.tar.xz'
 
   linux:
     runs-on: ubuntu-22.04
@@ -169,7 +188,8 @@ jobs:
     env:
       makeOptions: -j4
       makeVariables: local=false build=performance
-      nightly: bsnes-as-linux-${{github.run_number}}
+      #nightly: bsnes-as-linux-${{github.run_number}}
+      nightly: bsnes-as-linux
       buildVersion: ${{github.run_id}}
       platformOptions:
 
@@ -194,18 +214,18 @@ jobs:
         shell: bash
         name: 'make bsnes'
 
-      - run: |
-          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
-        shell: bash
-        name: 'make libretro'
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
 
       - run: |
           mkdir ${{env.nightly}}
           mkdir ${{env.nightly}}/Database
           mkdir ${{env.nightly}}/Firmware
           cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes
-          cp -a bsnes/out/bsnes_libretro.so ${{env.nightly}}/ || true
+          #cp -a bsnes/out/bsnes_libretro.so ${{env.nightly}}/ || true
           cp -a bsnes/out/discord_game_sdk.so ${{env.nightly}}/
           cp -a bsnes/Database/* ${{env.nightly}}/Database
           cp -a shaders ${{env.nightly}}/Shaders
@@ -214,7 +234,17 @@ jobs:
         shell: bash
         name: 'package'
 
+      - run: tar cJf ${{env.nightly}}.tar.xz ${{env.nightly}}/*
+        shell: bash
+        name: 'archive'
+
       - uses: actions/upload-artifact@v3
         with:
-          name: '${{env.nightly}}'
-          path: '${{env.nightly}}'
+          name: '${{env.nightly}}.tar.xz'
+          path: '${{env.nightly}}.tar.xz'
+
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: '${{env.nightly}}.tar.xz'

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -60,60 +60,61 @@ jobs:
           name: '${{env.nightly}}'
           path: '${{env.nightly}}'
 
-  win32:
-    runs-on: ubuntu-22.04
-
-    env:
-      makeOptions: -j4
-      makeVariables: local=false build=performance
-      nightly: bsnes-as-win32-${{github.run_number}}
-      buildVersion: ${{github.run_id}}
-      platformOptions: platform=windows arch=x86 compiler="i686-w64-mingw32-g++-posix" windres="i686-w64-mingw32-windres"
-
-    steps:
-      - run: |
-          echo 'win64'
-          set -e
-          sudo apt-get update
-          sudo apt-get -qq install -y --no-install-recommends ca-certificates make g++-mingw-w64-i686
-        shell: bash
-        name: 'setup'
-
-      - uses: actions/checkout@v3
-        name: Checkout
-        with:
-          fetch-depth: 0
-
-      - run: |
-          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
-          make ${{env.makeOptions}} -C bsnes target=bsnes ${{env.makeVariables}} ${{env.platformOptions}}
-        shell: bash
-        name: 'make bsnes'
-
-      - run: |
-          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
-        shell: bash
-        name: 'make libretro'
-
-      - run: |
-          mkdir ${{env.nightly}}
-          mkdir ${{env.nightly}}/Database
-          mkdir ${{env.nightly}}/Firmware
-          cp -a bsnes/out/bsnes.exe ${{env.nightly}}/bsnes.exe
-          cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
-          cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
-          cp -a bsnes/Database/* ${{env.nightly}}/Database
-          cp -a shaders ${{env.nightly}}/Shaders
-          cp -a scripts ${{env.nightly}}/scripts
-          cp -a GPLv3.txt ${{env.nightly}}
-        shell: bash
-        name: 'package'
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: '${{env.nightly}}'
-          path: '${{env.nightly}}'
+# NOTE: disabled due to compilation failures with angelscript/source/as_callfunc_x86.cpp
+#  win32:
+#    runs-on: ubuntu-22.04
+#
+#    env:
+#      makeOptions: -j4
+#      makeVariables: local=false build=performance
+#      nightly: bsnes-as-win32-${{github.run_number}}
+#      buildVersion: ${{github.run_id}}
+#      platformOptions: platform=windows arch=x86 compiler="i686-w64-mingw32-g++-posix" windres="i686-w64-mingw32-windres"
+#
+#    steps:
+#      - run: |
+#          echo 'win64'
+#          set -e
+#          sudo apt-get update
+#          sudo apt-get -qq install -y --no-install-recommends ca-certificates make g++-mingw-w64-i686
+#        shell: bash
+#        name: 'setup'
+#
+#      - uses: actions/checkout@v3
+#        name: Checkout
+#        with:
+#          fetch-depth: 0
+#
+#      - run: |
+#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+#          make ${{env.makeOptions}} -C bsnes target=bsnes ${{env.makeVariables}} ${{env.platformOptions}}
+#        shell: bash
+#        name: 'make bsnes'
+#
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
+#
+#      - run: |
+#          mkdir ${{env.nightly}}
+#          mkdir ${{env.nightly}}/Database
+#          mkdir ${{env.nightly}}/Firmware
+#          cp -a bsnes/out/bsnes.exe ${{env.nightly}}/bsnes.exe
+#          cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
+#          cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
+#          cp -a bsnes/Database/* ${{env.nightly}}/Database
+#          cp -a shaders ${{env.nightly}}/Shaders
+#          cp -a scripts ${{env.nightly}}/scripts
+#          cp -a GPLv3.txt ${{env.nightly}}
+#        shell: bash
+#        name: 'package'
+#
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: '${{env.nightly}}'
+#          path: '${{env.nightly}}'
 
 #  macos:
 #    imageName: 'macOS-10.14'
@@ -151,7 +152,54 @@ jobs:
 #        with:
 #          name: '${{env.nightly}}'
 #          path: '${{env.nightly}}'
-#
+
+  macos:
+    runs-on: macOS-10.14
+
+    env:
+      makeOptions: -j4
+      makeVariables: local=false build=performance
+      nightly: bsnes-as-macos-${{github.run_number}}
+      buildVersion: ${{github.run_id}}
+      platformOptions:
+
+    steps:
+      - run: |
+          echo 'macos'
+        shell: bash
+        name: 'setup'
+
+      - uses: actions/checkout@v3
+        name: Checkout
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+          make ${{env.makeOptions}} -C bsnes target=bsnes ${{env.makeVariables}} ${{env.platformOptions}}
+        shell: bash
+        name: 'make bsnes'
+
+      - run: |
+          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+        shell: bash
+        name: 'make libretro'
+
+      - run: |
+          mkdir ${{env.nightly}}
+          cp -a bsnes/out/bsnes.app ${{env.nightly}}/
+          cp -a bsnes/out/bsnes_libretro.dylib ${{env.nightly}}/ || true
+          cp -a scripts ${{env.nightly}}/scripts
+          cp -a GPLv3.txt ${{env.nightly}}/
+        shell: bash
+        name: 'package'
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: '${{env.nightly}}'
+          path: '${{env.nightly}}'
+
 #  linux:
 #    imageName: 'ubuntu-22.04'
 #    platformOptions:

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -154,7 +154,7 @@ jobs:
 #          path: '${{env.nightly}}'
 
   macos:
-    runs-on: macOS-10.14
+    runs-on: macos-12
 
     env:
       makeOptions: -j4

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -9,12 +9,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      makeOptions: -j2
+      makeOptions: -j4
       makeVariables: local=false build=performance
       nightly: bsnes-as-win64-${{github.run_number}}
       buildVersion: ${{github.run_id}}
       platformOptions: platform=windows compiler="x86_64-w64-mingw32-g++-posix" windres="x86_64-w64-mingw32-windres"
-      artifact: bsnes
 
     steps:
       - run: |
@@ -46,7 +45,7 @@ jobs:
           mkdir ${{env.nightly}}
           mkdir ${{env.nightly}}/Database
           mkdir ${{env.nightly}}/Firmware
-          cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes.exe
+          cp -a bsnes/out/bsnes.exe ${{env.nightly}}/bsnes.exe
           cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
           cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
           cp -a bsnes/Database/* ${{env.nightly}}/Database
@@ -60,7 +59,7 @@ jobs:
         with:
           name: '${{env.nightly}}'
           path: '${{env.nightly}}'
-#
+
 #  win32:
 #    runs-on: ubuntu-22.04
 #    env:

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -116,43 +116,6 @@ jobs:
 #          name: '${{env.nightly}}'
 #          path: '${{env.nightly}}'
 
-#  macos:
-#    imageName: 'macOS-10.14'
-#    platformOptions:
-#    setupScript: |
-#      echo 'macos'
-#    packageScript: |
-#      mkdir ${{env.nightly}}
-#      cp -a bsnes/out/bsnes.app ${{env.nightly}}/
-#      cp -a bsnes/out/bsnes_libretro.dylib ${{env.nightly}}/ || true
-#      cp -a scripts ${{env.nightly}}/scripts
-#      cp -a GPLv3.txt ${{env.nightly}}/
-#    steps:
-#      - run: ${{matrix.setupScript}}
-#        shell: bash
-#        name: 'setup'
-#
-#      - run: |
-#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
-#          make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
-#        shell: bash
-#        name: 'make bsnes'
-#
-#      - run: |
-#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-#          make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
-#        shell: bash
-#        name: 'make libretro'
-#
-#      - run: ${{matrix.packageScript}}
-#        shell: bash
-#        name: 'package'
-#
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          name: '${{env.nightly}}'
-#          path: '${{env.nightly}}'
-
   macos:
     runs-on: macos-12
 
@@ -200,74 +163,58 @@ jobs:
           name: '${{env.nightly}}'
           path: '${{env.nightly}}'
 
-#  linux:
-#    imageName: 'ubuntu-22.04'
-#    platformOptions:
-#    setupScript: |
-#      echo 'linux'
-#      set -e
-#      sudo apt-get update
-#      sudo apt-get -y install --no-upgrade --no-install-recommends build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libgtksourceview2.0-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev
-#    artifact: bsnes
-#    packageScript: |
-#      mkdir ${{env.nightly}}
-#      mkdir ${{env.nightly}}/Database
-#      mkdir ${{env.nightly}}/Firmware
-#      cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes
-#      cp -a bsnes/out/bsnes_libretro.so ${{env.nightly}}/ || true
-#      cp -a bsnes/out/discord_game_sdk.so ${{env.nightly}}/
-#      cp -a bsnes/Database/* ${{env.nightly}}/Database
-#      cp -a shaders ${{env.nightly}}/Shaders
-#      cp -a scripts ${{env.nightly}}/scripts
-#      cp -a GPLv3.txt ${{env.nightly}}
-#    steps:
-#      - run: ${{matrix.setupScript}}
-#        shell: bash
-#        name: 'setup'
-#
-#      - run: |
-#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
-#          make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
-#        shell: bash
-#        name: 'make bsnes'
-#
-#      - run: |
-#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-#          make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
-#        shell: bash
-#        name: 'make libretro'
-#
-#      - run: ${{matrix.packageScript}}
-#        shell: bash
-#        name: 'package'
-#
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          name: '${{env.nightly}}'
-#          path: '${{env.nightly}}'
+  linux:
+    runs-on: ubuntu-22.04
 
-#steps:
-#  - run: ${{matrix.setupScript}}
-#    shell: bash
-#    name: 'setup'
-#
-#  - run: |
-#      echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
-#      make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
-#    shell: bash
-#    name: 'make bsnes'
-#
-#  - run: |
-#      rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-#      make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
-#    shell: bash
-#    name: 'make libretro'
-#
-#  - run: ${{matrix.packageScript}}
-#    shell: bash
-#    name: 'package'
-#
-#  - uses: actions/upload-artifact@v3
-#    with:
-#      name: '${{env.nightly}}'
-#      path: '${{env.nightly}}'
+    env:
+      makeOptions: -j4
+      makeVariables: local=false build=performance
+      nightly: bsnes-as-linux-${{github.run_number}}
+      buildVersion: ${{github.run_id}}
+      platformOptions:
+
+    steps:
+      - run: |
+          echo 'linux'
+          set -e
+          sudo apt-get update
+          # libgtksourceview2.0-dev 
+          sudo apt-get -y install --no-upgrade --no-install-recommends build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev
+        shell: bash
+        name: 'setup'
+
+      - uses: actions/checkout@v3
+        name: Checkout
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+          make ${{env.makeOptions}} -C bsnes target=bsnes ${{env.makeVariables}} ${{env.platformOptions}}
+        shell: bash
+        name: 'make bsnes'
+
+      - run: |
+          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+        shell: bash
+        name: 'make libretro'
+
+      - run: |
+          mkdir ${{env.nightly}}
+          mkdir ${{env.nightly}}/Database
+          mkdir ${{env.nightly}}/Firmware
+          cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes
+          cp -a bsnes/out/bsnes_libretro.so ${{env.nightly}}/ || true
+          cp -a bsnes/out/discord_game_sdk.so ${{env.nightly}}/
+          cp -a bsnes/Database/* ${{env.nightly}}/Database
+          cp -a shaders ${{env.nightly}}/Shaders
+          cp -a scripts ${{env.nightly}}/scripts
+          cp -a GPLv3.txt ${{env.nightly}}
+        shell: bash
+        name: 'package'
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: '${{env.nightly}}'
+          path: '${{env.nightly}}'

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -1,0 +1,218 @@
+
+on:
+  push:
+   branches:
+     - unstable
+
+jobs:
+  win64:
+    runs-on: ubuntu-22.04
+
+    env:
+      makeOptions: -j2
+      makeVariables: local=false build=performance
+      nightly: bsnes-as-win64-${{github.run_number}}
+      buildVersion: ${{github.run_id}}
+      platformOptions: platform=windows compiler="x86_64-w64-mingw32-g++-posix" windres="x86_64-w64-mingw32-windres"
+      artifact: bsnes
+
+    steps:
+      - run: |
+          echo 'win64'
+          set -e
+          sudo apt-get update
+          sudo apt-get -qq install -y --no-install-recommends ca-certificates make g++-mingw-w64-x86-64
+        shell: bash
+        name: 'setup'
+
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+          make ${{env.makeOptions}} -C bsnes target=bsnes ${{env.makeVariables}} ${{env.platformOptions}}
+        shell: bash
+        name: 'make bsnes'
+
+      - run: |
+          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+        shell: bash
+        name: 'make libretro'
+
+      - run: |
+          mkdir ${{env.nightly}}
+          mkdir ${{env.nightly}}/Database
+          mkdir ${{env.nightly}}/Firmware
+          cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes.exe
+          cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
+          cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
+          cp -a bsnes/Database/* ${{env.nightly}}/Database
+          cp -a shaders ${{env.nightly}}/Shaders
+          cp -a scripts ${{env.nightly}}/scripts
+          cp -a GPLv3.txt ${{env.nightly}}
+        shell: bash
+        name: 'package'
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: '${{env.nightly}}'
+          path: '${{env.nightly}}'
+#
+#  win32:
+#    runs-on: ubuntu-22.04
+#    env:
+#      platformOptions: platform=windows arch=x86 compiler="i686-w64-mingw32-g++-posix" windres="i686-w64-mingw32-windres"
+#      artifact: bsnes
+#    setupScript: |
+#      echo 'win32'
+#      set -e
+#      sudo apt-get update
+#      sudo apt-get -qq install -y --no-install-recommends ca-certificates make g++-mingw-w64-i686
+#    packageScript: |
+#      mkdir ${{env.nightly}}
+#      mkdir ${{env.nightly}}/Database
+#      mkdir ${{env.nightly}}/Firmware
+#      cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes.exe
+#      cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
+#      cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
+#      cp -a bsnes/Database/* ${{env.nightly}}/Database
+#      cp -a shaders ${{env.nightly}}/Shaders
+#      cp -a scripts ${{env.nightly}}/scripts
+#      cp -a GPLv3.txt ${{env.nightly}}
+#    steps:
+#      - run: ${{matrix.setupScript}}
+#        shell: bash
+#        name: 'setup'
+#
+#      - run: |
+#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+#          make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
+#        shell: bash
+#        name: 'make bsnes'
+#
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
+#
+#      - run: ${{matrix.packageScript}}
+#        shell: bash
+#        name: 'package'
+#
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: '${{env.nightly}}'
+#          path: '${{env.nightly}}'
+#
+#  macos:
+#    imageName: 'macOS-10.14'
+#    platformOptions:
+#    setupScript: |
+#      echo 'macos'
+#    packageScript: |
+#      mkdir ${{env.nightly}}
+#      cp -a bsnes/out/bsnes.app ${{env.nightly}}/
+#      cp -a bsnes/out/bsnes_libretro.dylib ${{env.nightly}}/ || true
+#      cp -a scripts ${{env.nightly}}/scripts
+#      cp -a GPLv3.txt ${{env.nightly}}/
+#    steps:
+#      - run: ${{matrix.setupScript}}
+#        shell: bash
+#        name: 'setup'
+#
+#      - run: |
+#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+#          make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
+#        shell: bash
+#        name: 'make bsnes'
+#
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
+#
+#      - run: ${{matrix.packageScript}}
+#        shell: bash
+#        name: 'package'
+#
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: '${{env.nightly}}'
+#          path: '${{env.nightly}}'
+#
+#  linux:
+#    imageName: 'ubuntu-22.04'
+#    platformOptions:
+#    setupScript: |
+#      echo 'linux'
+#      set -e
+#      sudo apt-get update
+#      sudo apt-get -y install --no-upgrade --no-install-recommends build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libgtksourceview2.0-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev
+#    artifact: bsnes
+#    packageScript: |
+#      mkdir ${{env.nightly}}
+#      mkdir ${{env.nightly}}/Database
+#      mkdir ${{env.nightly}}/Firmware
+#      cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes
+#      cp -a bsnes/out/bsnes_libretro.so ${{env.nightly}}/ || true
+#      cp -a bsnes/out/discord_game_sdk.so ${{env.nightly}}/
+#      cp -a bsnes/Database/* ${{env.nightly}}/Database
+#      cp -a shaders ${{env.nightly}}/Shaders
+#      cp -a scripts ${{env.nightly}}/scripts
+#      cp -a GPLv3.txt ${{env.nightly}}
+#    steps:
+#      - run: ${{matrix.setupScript}}
+#        shell: bash
+#        name: 'setup'
+#
+#      - run: |
+#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+#          make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
+#        shell: bash
+#        name: 'make bsnes'
+#
+#      - run: |
+#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#          make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
+#        shell: bash
+#        name: 'make libretro'
+#
+#      - run: ${{matrix.packageScript}}
+#        shell: bash
+#        name: 'package'
+#
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: '${{env.nightly}}'
+#          path: '${{env.nightly}}'
+
+#steps:
+#  - run: ${{matrix.setupScript}}
+#    shell: bash
+#    name: 'setup'
+#
+#  - run: |
+#      echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+#      make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
+#    shell: bash
+#    name: 'make bsnes'
+#
+#  - run: |
+#      rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+#      make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
+#    shell: bash
+#    name: 'make libretro'
+#
+#  - run: ${{matrix.packageScript}}
+#    shell: bash
+#    name: 'package'
+#
+#  - uses: actions/upload-artifact@v3
+#    with:
+#      name: '${{env.nightly}}'
+#      path: '${{env.nightly}}'

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         name: 'setup'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
         with:
           fetch-depth: 0
@@ -60,53 +60,61 @@ jobs:
           name: '${{env.nightly}}'
           path: '${{env.nightly}}'
 
-#  win32:
-#    runs-on: ubuntu-22.04
-#    env:
-#      platformOptions: platform=windows arch=x86 compiler="i686-w64-mingw32-g++-posix" windres="i686-w64-mingw32-windres"
-#      artifact: bsnes
-#    setupScript: |
-#      echo 'win32'
-#      set -e
-#      sudo apt-get update
-#      sudo apt-get -qq install -y --no-install-recommends ca-certificates make g++-mingw-w64-i686
-#    packageScript: |
-#      mkdir ${{env.nightly}}
-#      mkdir ${{env.nightly}}/Database
-#      mkdir ${{env.nightly}}/Firmware
-#      cp -a bsnes/out/bsnes ${{env.nightly}}/bsnes.exe
-#      cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
-#      cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
-#      cp -a bsnes/Database/* ${{env.nightly}}/Database
-#      cp -a shaders ${{env.nightly}}/Shaders
-#      cp -a scripts ${{env.nightly}}/scripts
-#      cp -a GPLv3.txt ${{env.nightly}}
-#    steps:
-#      - run: ${{matrix.setupScript}}
-#        shell: bash
-#        name: 'setup'
-#
-#      - run: |
-#          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
-#          make ${{env.makeOptions) -C bsnes target=bsnes ${{env.makeVariables}} ${{matrix.platformOptions}}
-#        shell: bash
-#        name: 'make bsnes'
-#
-#      - run: |
-#          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
-#          make ${{env.makeOptions) -C bsnes target=libretro ${{env.makeVariables}} ${{matrix.platformOptions}} || true
-#        shell: bash
-#        name: 'make libretro'
-#
-#      - run: ${{matrix.packageScript}}
-#        shell: bash
-#        name: 'package'
-#
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          name: '${{env.nightly}}'
-#          path: '${{env.nightly}}'
-#
+  win32:
+    runs-on: ubuntu-22.04
+
+    env:
+      makeOptions: -j4
+      makeVariables: local=false build=performance
+      nightly: bsnes-as-win32-${{github.run_number}}
+      buildVersion: ${{github.run_id}}
+      platformOptions: platform=windows arch=x86 compiler="i686-w64-mingw32-g++-posix" windres="i686-w64-mingw32-windres"
+
+    steps:
+      - run: |
+          echo 'win64'
+          set -e
+          sudo apt-get update
+          sudo apt-get -qq install -y --no-install-recommends ca-certificates make g++-mingw-w64-i686
+        shell: bash
+        name: 'setup'
+
+      - uses: actions/checkout@v3
+        name: Checkout
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo '#define BSNES_BUILD_NUMBER "'"${{env.buildVersion}}"'"' > bsnes/emulator/version.generated.hpp
+          make ${{env.makeOptions}} -C bsnes target=bsnes ${{env.makeVariables}} ${{env.platformOptions}}
+        shell: bash
+        name: 'make bsnes'
+
+      - run: |
+          rm -f bsnes/obj/sfc-*.o bsnes/obj/core.o bsnes/obj/emulator.o || true
+          make ${{env.makeOptions}} -C bsnes target=libretro ${{env.makeVariables}} ${{env.platformOptions}} || true
+        shell: bash
+        name: 'make libretro'
+
+      - run: |
+          mkdir ${{env.nightly}}
+          mkdir ${{env.nightly}}/Database
+          mkdir ${{env.nightly}}/Firmware
+          cp -a bsnes/out/bsnes.exe ${{env.nightly}}/bsnes.exe
+          cp -a bsnes/out/bsnes_libretro.dll ${{env.nightly}}/ || true
+          cp -a bsnes/out/discord_game_sdk.dll ${{env.nightly}}/
+          cp -a bsnes/Database/* ${{env.nightly}}/Database
+          cp -a shaders ${{env.nightly}}/Shaders
+          cp -a scripts ${{env.nightly}}/scripts
+          cp -a GPLv3.txt ${{env.nightly}}
+        shell: bash
+        name: 'package'
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: '${{env.nightly}}'
+          path: '${{env.nightly}}'
+
 #  macos:
 #    imageName: 'macOS-10.14'
 #    platformOptions:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,55 @@ some rudimentary script function bindings between the bsnes emulator and AngelSc
 Download nightly binary builds here:
 https://dev.azure.com/ALttPO/alttpo/_build?definitionId=3&_a=summary&repositoryFilter=3
 
+Building on macOS
+------------------
+
+This repo builds natively on both Apple Silicon (arm64) and Intel (x86_64) Macs — the `GNUmakefile`
+build system auto-detects your platform and architecture, and macOS needs no extra dependencies
+beyond Xcode's command line tools (the UI is built directly against Cocoa; there's no GTK/Qt/Homebrew
+requirement like the Linux build has).
+
+1. Install the Xcode command line tools if you haven't already:
+   ```
+   $ xcode-select --install
+   ```
+2. Clone this repository:
+   ```
+   $ git clone https://github.com/alttpo/bsnes-as.git
+   $ cd bsnes-as
+   ```
+3. Build it:
+   ```
+   $ make -C bsnes build=performance -j$(sysctl -n hw.ncpu)
+   ```
+   This produces `bsnes/out/bsnes.app`. `build=performance` matches what the official CI builds use
+   (`-O3`); the default `local=true` adds `-march=native`, which is fine as long as you run the
+   binary on the same Mac you built it on (drop it, e.g. `make -C bsnes build=performance local=false`,
+   if you intend to copy the binary to a different machine).
+4. Run it directly from `bsnes/out/bsnes.app`, or install it system-wide:
+   ```
+   $ make -C bsnes install
+   ```
+   which copies it to `/Applications/bsnes.app` and sets up `~/Library/Application Support/bsnes/`.
+
+Notes:
+- Discord Rich Presence integration is only available on `x86_64` (there's no arm64 build of the
+  Discord Game SDK bundled in `lib/`) — the build system detects this automatically via `arch` and
+  disables it (`-DDISCORD_DISABLE=1`) rather than failing, so this doesn't block an Apple Silicon build.
+- A build you compile yourself isn't downloaded from the internet, so it never picks up the
+  `com.apple.quarantine` extended attribute and won't trigger Gatekeeper's "app is damaged" dialog —
+  that dialog is a downloaded-and-then-extracted-by-Archive-Utility artifact, not a build issue. If
+  you hit that dialog with a **pre-built** binary (see the MacOS Catalina section below for a version
+  of this), the fix is to extract with `tar`/a third-party archiver instead of Archive Utility.app, or
+  strip the attribute directly: `xattr -cr /path/to/bsnes.app`.
+- If you're testing multiple downloaded/rebuilt copies of this app over time, be aware that macOS's
+  LaunchServices tracks them all under the same bundle identifier (`org.byuu.bsnes`). Stale duplicate
+  registrations (e.g. old copies still sitting in `~/Downloads` or `~/.Trash`) can cause file-open
+  requests (double-clicking a ROM, "Open With") to route unpredictably. Clean up old copies you no
+  longer need, or run `lsregister -gc` (found under
+  `/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/`)
+  to garbage-collect stale entries.
+
 Screenshots
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://dev.azure.com/ALttPO/alttpo/_build?definitionId=3&_a=summary&repositoryF
 Building on macOS
 ------------------
 
-This repo builds natively on both Apple Silicon (arm64) and Intel (x86_64) Macs — the `GNUmakefile`
+This repo builds natively on both Apple Silicon (arm64) and Intel (x86_64) Macs. The `GNUmakefile`
 build system auto-detects your platform and architecture, and macOS needs no extra dependencies
 beyond Xcode's command line tools (the UI is built directly against Cocoa; there's no GTK/Qt/Homebrew
 requirement like the Linux build has).
@@ -37,23 +37,14 @@ requirement like the Linux build has).
    ```
    which copies it to `/Applications/bsnes.app` and sets up `~/Library/Application Support/bsnes/`.
 
-Notes:
-- Discord Rich Presence integration is only available on `x86_64` (there's no arm64 build of the
-  Discord Game SDK bundled in `lib/`) — the build system detects this automatically via `arch` and
-  disables it (`-DDISCORD_DISABLE=1`) rather than failing, so this doesn't block an Apple Silicon build.
-- A build you compile yourself isn't downloaded from the internet, so it never picks up the
-  `com.apple.quarantine` extended attribute and won't trigger Gatekeeper's "app is damaged" dialog —
-  that dialog is a downloaded-and-then-extracted-by-Archive-Utility artifact, not a build issue. If
-  you hit that dialog with a **pre-built** binary (see the MacOS Catalina section below for a version
-  of this), the fix is to extract with `tar`/a third-party archiver instead of Archive Utility.app, or
-  strip the attribute directly: `xattr -cr /path/to/bsnes.app`.
-- If you're testing multiple downloaded/rebuilt copies of this app over time, be aware that macOS's
-  LaunchServices tracks them all under the same bundle identifier (`org.byuu.bsnes`). Stale duplicate
-  registrations (e.g. old copies still sitting in `~/Downloads` or `~/.Trash`) can cause file-open
-  requests (double-clicking a ROM, "Open With") to route unpredictably. Clean up old copies you no
-  longer need, or run `lsregister -gc` (found under
-  `/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/`)
-  to garbage-collect stale entries.
+Note: Discord Rich Presence integration is only available on `x86_64` (there's no arm64 build of the
+Discord Game SDK bundled in `lib/`). The build system detects this automatically via `arch` and
+disables it (`-DDISCORD_DISABLE=1`) rather than failing, so this doesn't block an Apple Silicon build.
+
+A build you compile yourself is never downloaded from the internet, so it never picks up the
+`com.apple.quarantine` extended attribute and won't trigger Gatekeeper's "app is damaged" dialog. If
+you're working with a **pre-built** binary instead and hit that dialog, or ROMs won't open when
+double-clicked, see [Troubleshooting](#troubleshooting) below.
 
 Screenshots
 ---
@@ -139,5 +130,11 @@ Refer to [this document](angelscript.md) for details on the AngelScript interfac
 Troubleshooting
 ===
 
-For users of MacOS Catalina (10.15), be sure to extract the download archive using https://www.keka.io/en/ file
-archiver. DO NOT use the built-in "Archive Utility.app".
+**"bsnes is damaged and can't be opened"**: extract the downloaded archive with `tar` from Terminal,
+or a third-party archiver like [Keka](https://www.keka.io/en/), not the built-in "Archive
+Utility.app". If you've already extracted it, just run `xattr -cr /path/to/bsnes.app` instead of
+re-extracting.
+
+**Double-clicking a ROM doesn't open it, or opens the wrong copy of bsnes**: this usually means
+macOS has multiple old copies of bsnes registered from previous downloads. Delete old copies you no
+longer need and re-launch the one you want to keep once.

--- a/bsnes/target-bsnes/GNUmakefile
+++ b/bsnes/target-bsnes/GNUmakefile
@@ -27,13 +27,15 @@ obj/ui-resource.o: $(ui)/resource/resource.cpp
 
 all: $(objects) $(hiro.objects) $(ruby.objects) $(angel.objects) $(discord.objects)
 	$(info Linking out/$(name) ...)
-ifeq ($(platform),windows)
+ifeq ($(discord),true)
+ ifeq ($(platform),windows)
 	cp ../lib/$(arch)/discord_game_sdk.dll* .
-else ifeq ($(platform),macos)
+ else ifeq ($(platform),macos)
 	cp ../lib/$(arch)/discord_game_sdk.bundle .
 	cp ../lib/$(arch)/discord_game_sdk.dylib .
-else ifeq ($(platform),linux)
+ else ifeq ($(platform),linux)
 	cp ../lib/$(arch)/discord_game_sdk.so .
+ endif
 endif
 	+@$(compiler) -o out/$(name) $(hiro.objects) $(ruby.objects) $(angel.objects) $(discord.objects) $(objects) $(hiro.options) $(ruby.options) $(angel.options) $(discord.options) $(options)
 ifeq ($(platform),windows)

--- a/bsnes/target-bsnes/presentation/presentation.cpp
+++ b/bsnes/target-bsnes/presentation/presentation.cpp
@@ -279,6 +279,7 @@ auto Presentation::create() -> void {
   #if defined(PLATFORM_MACOS)
   Application::Cocoa::onAbout([&] { about.doActivate(); });
   Application::Cocoa::onActivate([&] { setFocused(); });
+  Application::Cocoa::onOpen([&](string location) { onDrop({location}); });
   Application::Cocoa::onPreferences([&] { settingsWindow.show(2); });
   Application::Cocoa::onQuit([&] { doClose(); });
   #endif

--- a/bsnes/target-bsnes/resource/bsnes.plist
+++ b/bsnes/target-bsnes/resource/bsnes.plist
@@ -14,5 +14,135 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Super Famicom ROM Image</string>
+      <key>CFBundleTypeRole</key>
+      <string>Viewer</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>sfc</string>
+        <string>smc</string>
+      </array>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>org.byuu.bsnes-as.sfc-rom</string>
+      </array>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Game Boy ROM Image</string>
+      <key>CFBundleTypeRole</key>
+      <string>Viewer</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>gb</string>
+        <string>gbc</string>
+      </array>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>org.byuu.bsnes-as.gb-rom</string>
+      </array>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>BS-X / Sufami Turbo ROM Image</string>
+      <key>CFBundleTypeRole</key>
+      <string>Viewer</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>bs</string>
+        <string>st</string>
+      </array>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>org.byuu.bsnes-as.bs-rom</string>
+        <string>org.byuu.bsnes-as.st-rom</string>
+      </array>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+    </dict>
+  </array>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>org.byuu.bsnes-as.sfc-rom</string>
+      <key>UTTypeDescription</key>
+      <string>Super Famicom ROM Image</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>sfc</string>
+          <string>smc</string>
+        </array>
+      </dict>
+    </dict>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>org.byuu.bsnes-as.gb-rom</string>
+      <key>UTTypeDescription</key>
+      <string>Game Boy ROM Image</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>gb</string>
+          <string>gbc</string>
+        </array>
+      </dict>
+    </dict>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>org.byuu.bsnes-as.bs-rom</string>
+      <key>UTTypeDescription</key>
+      <string>BS-X ROM Image</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>bs</string>
+        </array>
+      </dict>
+    </dict>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>org.byuu.bsnes-as.st-rom</string>
+      <key>UTTypeDescription</key>
+      <string>Sufami Turbo ROM Image</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>st</string>
+        </array>
+      </dict>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/bsnes/target-bsnes/settings/settings.cpp
+++ b/bsnes/target-bsnes/settings/settings.cpp
@@ -249,6 +249,9 @@ auto SettingsWindow::show(int index) -> void {
   if(index == 7) compatibilitySettings.setVisible(true);
   if(index == 8) driverSettings.setVisible(true);
   panelContainer.resize();
+  inputSettings.refreshMappings();
+  hotkeySettings.refreshMappings();
+  Application::processEvents();
   setVisibleAndActivate();
   setFocused();
   panelList.setFocused();

--- a/discord/GNUmakefile
+++ b/discord/GNUmakefile
@@ -9,7 +9,11 @@ ifeq ($(platform),windows)
   # arch is 'x86_64' or 'x86'
   discord.options := -L../lib/$(arch) -ldiscord_game_sdk.dll
 else ifeq ($(platform),macos)
-  discord.options := discord_game_sdk.bundle
+  ifeq ($(arch),x86_64)
+    discord.options := discord_game_sdk.bundle
+  else
+    discord = false
+  endif
 else ifeq ($(platform),linux)
   ifeq ($(arch),x86_64)
     discord.options := -Wl,-rpath,'${ORIGIN}':./ discord_game_sdk.so

--- a/discord/GNUmakefile
+++ b/discord/GNUmakefile
@@ -22,7 +22,7 @@ endif
 
 ifeq ($(discord),false)
   discord.flags += -DDISCORD_DISABLE=1
-  discord.options :=
+  discord.options =
 endif
 
 discord.objects := achievement_manager \

--- a/discord/ffi.h
+++ b/discord/ffi.h
@@ -7,7 +7,10 @@ extern "C" {
 
 #include <stdint.h>
 #include <string.h>
-#ifndef __cplusplus
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
 #include <stdbool.h>
 #endif
 

--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -9,8 +9,8 @@ ifeq ($(platform),windows)
   endif
 
   ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0)
-    hiro.options = $(shell pkg-config --libs gtk+-2.0 gtksourceview-2.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0)
+    hiro.options = $(shell pkg-config --libs gtk+-2.0)
   endif
 
   ifeq ($(hiro),gtk3)
@@ -36,8 +36,8 @@ ifneq ($(filter $(platform),linux bsd),)
   endif
 
   ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0)
-    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0 gtksourceview-2.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0)
+    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0)
   endif
 
   ifeq ($(hiro),gtk3)

--- a/hiro/cocoa/application.cpp
+++ b/hiro/cocoa/application.cpp
@@ -15,6 +15,17 @@
   return NO;
 }
 
+-(void) handleOpenDocumentsEvent:(NSAppleEventDescriptor*)event withReplyEvent:(NSAppleEventDescriptor*)replyEvent {
+  using hiro::Application;
+  NSAppleEventDescriptor* fileList = [event paramDescriptorForKeyword:keyDirectObject];
+  for(NSInteger i = 1; i <= [fileList numberOfItems]; i++) {
+    NSAppleEventDescriptor* item = [fileList descriptorAtIndex:i];
+    NSURL* url = [NSURL URLWithString:[item stringValue]];
+    string path = url && [url isFileURL] ? [[url path] UTF8String] : [[item stringValue] UTF8String];
+    if(path) Application::Cocoa::doOpen(path);
+  }
+}
+
 -(void) run:(NSTimer*)timer {
   using hiro::Application;
   if(Application::state().onMain) Application::doMain();
@@ -100,6 +111,19 @@ auto pApplication::initialize() -> void {
     [NSApplication sharedApplication];
     cocoaDelegate = [[CocoaDelegate alloc] init];
     [NSApp setDelegate:cocoaDelegate];
+
+    //register as early as possible (before any of the application's own, potentially slow,
+    //startup work runs) so a cold-launch "open document" Apple Event isn't missed: on a cold
+    //launch (double-click / Finder "Open With"), macOS can deliver this event before the app
+    //has finished constructing its UI, and it will not be redelivered if missed
+    [[NSAppleEventManager sharedAppleEventManager] setEventHandler:cocoaDelegate
+                                                        andSelector:@selector(handleOpenDocumentsEvent:withReplyEvent:)
+                                                      forEventClass:kCoreEventClass
+                                                         andEventID:kAEOpenDocuments];
+
+    //give the just-registered handler a chance to receive any open-document event that is
+    //already queued for this process before proceeding into the application's slow startup path
+    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
   }
 }
 

--- a/hiro/cocoa/application.hpp
+++ b/hiro/cocoa/application.hpp
@@ -4,6 +4,7 @@
 }
 -(NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication*)sender;
 -(BOOL) applicationShouldHandleReopen:(NSApplication*)application hasVisibleWindows:(BOOL)flag;
+-(void) handleOpenDocumentsEvent:(NSAppleEventDescriptor*)event withReplyEvent:(NSAppleEventDescriptor*)replyEvent;
 -(void) run:(NSTimer*)timer;
 -(void) updateInDock:(NSTimer*)timer;
 @end

--- a/hiro/components.hpp
+++ b/hiro/components.hpp
@@ -66,7 +66,7 @@
 #define Hiro_ProgressBar
 #define Hiro_RadioButton
 #define Hiro_RadioLabel
-#define Hiro_SourceEdit
+//#define Hiro_SourceEdit
 #define Hiro_TabFrame
 #define Hiro_TableView
 #define Hiro_TextEdit

--- a/hiro/core/application.cpp
+++ b/hiro/core/application.cpp
@@ -109,6 +109,14 @@ auto Application::Cocoa::doActivate() -> void {
   if(state().cocoa.onActivate) return state().cocoa.onActivate();
 }
 
+auto Application::Cocoa::doOpen(const string& location) -> void {
+  //the open-document event can arrive (via a raw Apple Event handler registered at the
+  //earliest possible moment) before the application has finished constructing its UI and
+  //registered a real onOpen callback: buffer it so it isn't silently dropped on a cold launch
+  if(state().cocoa.onOpen) return state().cocoa.onOpen(location);
+  state().cocoa.pendingOpen.append(location);
+}
+
 auto Application::Cocoa::doPreferences() -> void {
   if(state().cocoa.onPreferences) return state().cocoa.onPreferences();
 }
@@ -123,6 +131,15 @@ auto Application::Cocoa::onAbout(const function<void ()>& callback) -> void {
 
 auto Application::Cocoa::onActivate(const function<void ()>& callback) -> void {
   state().cocoa.onActivate = callback;
+}
+
+auto Application::Cocoa::onOpen(const function<void (string)>& callback) -> void {
+  state().cocoa.onOpen = callback;
+  if(callback) {
+    auto pending = move(state().cocoa.pendingOpen);
+    state().cocoa.pendingOpen = {};
+    for(auto& location : pending) callback(location);
+  }
 }
 
 auto Application::Cocoa::onPreferences(const function<void ()>& callback) -> void {

--- a/hiro/core/application.hpp
+++ b/hiro/core/application.hpp
@@ -28,10 +28,12 @@ struct Application {
   struct Cocoa {
     static auto doAbout() -> void;
     static auto doActivate() -> void;
+    static auto doOpen(const string& location) -> void;
     static auto doPreferences() -> void;
     static auto doQuit() -> void;
     static auto onAbout(const function<void ()>& callback = {}) -> void;
     static auto onActivate(const function<void ()>& callback = {}) -> void;
+    static auto onOpen(const function<void (string)>& callback = {}) -> void;
     static auto onPreferences(const function<void ()>& callback = {}) -> void;
     static auto onQuit(const function<void ()>& callback = {}) -> void;
   };
@@ -56,6 +58,8 @@ struct Application {
     struct Cocoa {
       function<void ()> onAbout;
       function<void ()> onActivate;
+      function<void (string)> onOpen;
+      vector<string> pendingOpen;
       function<void ()> onPreferences;
       function<void ()> onQuit;
     } cocoa;

--- a/nall/decode/rle.hpp
+++ b/nall/decode/rle.hpp
@@ -12,7 +12,7 @@ inline auto RLE(array_view<uint8_t> input) -> vector<uint8_t> {
 
   uint base = 0;
   uint64_t size = 0;
-  for(uint byte : range(8)) size |= load() << byte * 8;
+  for(uint byte : range(8)) size |= (uint64_t)load() << byte * 8;
   output.resize(size);
 
   auto read = [&]() -> uint64_t {


### PR DESCRIPTION
This PR fixes three unrelated bugs, all reproduced and verified on Apple Silicon (macOS 26 Tahoe). None of the changes affect SNES emulation (`sfc/`, `processor/`); they are limited to save-state I/O, UI, and macOS integration.

1. **Fix save-state load crash (heap corruption).**
   `nall::Decode::RLE` reconstructed the uncompressed size using undefined behavior (shifting a promoted 32-bit value by up to 56 bits), producing an invalid allocation size on arm64. This corrupted the heap during decompression and caused a crash shortly afterward. The decoder now matches the encoder's 64-bit implementation.

2. **Fix empty Input/Hotkeys mapping list on first open.**
   `SettingsWindow::show()` activated the window through the base `Window` class, bypassing `SettingsWindow::setVisible()`, which refreshes the mapping list. As a result, mappings only appeared after changing the device dropdown. The mappings are now refreshed whenever the window is shown.

3. **Fix opening ROMs via Finder ("Open With" / double-click).**
   bsnes previously had no document-opening path on macOS because `Info.plist` did not declare supported document types and no Apple Event handler was registered. This PR:

   * registers a `kAEOpenDocuments` handler early in startup,
   * buffers open requests until the application is ready, and
   * adds document type declarations for supported ROM formats (`.sfc`, `.smc`, `.gb`, `.gbc`, `.bs`, `.st`) using `LSHandlerRank: Alternate`.

   During testing I also found duplicate LaunchServices registrations can prevent file opening on some development systems. That's an environment issue rather than a code bug, but reviewers who can't reproduce may want to clear stale registrations with `lsregister`.

## Testing

Verified manually on Apple Silicon (macOS 26 Tahoe):

* Save-state load no longer crashes.
* ``Settings -> Input/Hotkeys`` populates mappings immediately on first open.
* Opening a ROM via Finder (`open -a bsnes.app romfile.sfc`) successfully launches the emulator and loads the ROM.